### PR TITLE
Fixing Ansible ad-hoc commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,19 +106,19 @@ ansible all -m ping -i inventory -vvvv
 Let's install a web server, called nginx (say like engine-X), on the VM. The web server will automatically start.
 
 ```shell
-ansible all -s -m apt -i inventory -a 'pkg=nginx state=installed'
+ansible all -b -m apt -i inventory -a 'pkg=nginx state=installed'
 ```
 
 Open a browser and enter in your VM's ip address, e.g. http://192.168.14.14:80/
 
 Removing nginx:
 ```shell
-ansible all -s -m apt -i inventory -a 'pkg=nginx state=removed'
+ansible all -b -m apt -i inventory -a 'pkg=nginx state=removed'
 ```
 
 Actually, nginx is a metapackage, so you also need to run this:
 ```shell
-ansible all -s -m shell -i inventory -a 'sudo apt-get -y autoremove'
+ansible all -b -m shell -i inventory -a 'sudo apt-get -y autoremove'
 ```
 Now if you reload the address you opened in your browser, the webserver should be dead!
 


### PR DESCRIPTION
In newer versions of Ansible `-s` is changed to `-b`.